### PR TITLE
Add links between tasks

### DIFF
--- a/src/components/assignees/NameTag.vue
+++ b/src/components/assignees/NameTag.vue
@@ -55,7 +55,7 @@ import AssigneeForm from "@/components/assignees/AssigneeForm";
 import { isAssignee } from "@/store/assignees/schema";
 import { modules } from "@/store";
 import { remove } from "@/store/assignees/types";
-import { mapMutations } from "vuex";
+import { mapActions } from "vuex";
 
 export default {
   name: "NameTag",
@@ -70,7 +70,7 @@ export default {
     }
   },
   methods: {
-    ...mapMutations(modules.assignees, {
+    ...mapActions(modules.assignees, {
       deleteAssignee: remove
     })
   },

--- a/src/components/projects/ProjectButton.vue
+++ b/src/components/projects/ProjectButton.vue
@@ -52,7 +52,7 @@
 </template>
 
 <script>
-import { mapGetters, mapMutations } from "vuex";
+import { mapActions, mapGetters, mapMutations } from "vuex";
 import { modules } from "@/store";
 import { getSelected, select, remove } from "@/store/projects/types";
 import ProjectForm from "@/components/projects/ProjectForm";
@@ -82,7 +82,8 @@ export default {
     }
   },
   methods: {
-    ...mapMutations(modules.projects, { select, remove })
+    ...mapMutations(modules.projects, { select }),
+    ...mapActions(modules.projects, { remove })
   },
   data() {
     return {

--- a/src/components/projects/ProjectButtons.vue
+++ b/src/components/projects/ProjectButtons.vue
@@ -27,14 +27,9 @@
 </template>
 
 <script>
-import { mapGetters, mapMutations } from "vuex";
+import { mapGetters } from "vuex";
 import { modules } from "@/store";
-import {
-  getAll as getAllProjects,
-  getSelected,
-  select,
-  remove
-} from "@/store/projects/types";
+import { getAll as getAllProjects, getSelected } from "@/store/projects/types";
 import ProjectForm from "@/components/projects/ProjectForm";
 import ProjectButton from "@/components/projects/ProjectButton";
 
@@ -52,9 +47,6 @@ export default {
     })
   },
 
-  methods: {
-    ...mapMutations(modules.projects, { select, remove })
-  },
   data() {
     return {
       dialog: false

--- a/src/components/tasks/TaskForm.vue
+++ b/src/components/tasks/TaskForm.vue
@@ -46,8 +46,8 @@
 
 <script>
 import moment from "moment";
-import { mapGetters, mapMutations } from "vuex";
-import { add, edit } from "@/store/tasks/types";
+import { mapActions, mapGetters, mapMutations } from "vuex";
+import { add, update } from "@/store/tasks/types";
 import DatePicker from "@/components/tasks/DatePicker";
 import { getAll as getAllAssignees } from "@/store/assignees/types";
 import { modules } from "@/store";
@@ -80,7 +80,8 @@ export default {
     this.values.project = this.task?.project || this.selectedProject;
   },
   methods: {
-    ...mapMutations(modules.tasks, { addTask: add, editTask: edit }),
+    ...mapMutations(modules.tasks, { addTask: add }),
+    ...mapActions(modules.tasks, { editTask: update }),
     handleSubmit(e) {
       e.preventDefault();
       const submitValues = {

--- a/src/components/timeline/Calendar.vue
+++ b/src/components/timeline/Calendar.vue
@@ -1,26 +1,9 @@
 <template>
   <div class="scroll-wrapper" @scroll="onScroll">
     <div class="calendar" :style="cssVars">
-      <Draggable
-        v-model="assignees"
-        @start="dragging = true"
-        @end="dragging = false"
-        class="drag-wrapper"
-        handle=".lane__name-tag"
-      >
-        <Lane
-          v-for="(assignee, index) in assignees"
-          class="lane"
-          :style="`--index: ${index};`"
-          :key="assignee.id"
-          :assignee="assignee"
-          :dates="days"
-          :column-width="columnWidth"
-          :scroll-offset-x="offsetX"
-        >
-          <NameTag class="lane__name-tag" :assignee="assignee"></NameTag>
-        </Lane>
-      </Draggable>
+      <div class="content">
+        <slot :scrollOffsetX="offsetX" :dates="days"></slot>
+      </div>
       <Day
         v-for="(day, index) in days"
         class="day"
@@ -35,38 +18,20 @@
 <script>
 import Moment from "moment";
 import { extendMoment } from "moment-range";
-import Draggable from "vuedraggable";
-
 import Day from "@/components/timeline/Day";
-import Lane from "@/components/timeline/Lane";
-import { getAll, set } from "@/store/assignees/types";
-import { modules } from "@/store";
-import NameTag from "@/components/assignees/NameTag";
 
 const moment = extendMoment(Moment);
 
 export default {
   name: "Calendar",
   components: {
-    Day,
-    Lane,
-    Draggable,
-    NameTag
+    Day
   },
   computed: {
-    assignees: {
-      get() {
-        return this.$store.getters[`${modules.assignees}/${getAll}`];
-      },
-      set(value) {
-        this.$store.commit(`${modules.assignees}/${set}`, value);
-      }
-    },
     cssVars() {
       return {
         "--columns": this.days.length,
         "--column-width": `${this.columnWidth}px`,
-        "--lanes": this.assignees.length,
         "--offset-x": `${this.offsetX}px`
       };
     }
@@ -131,33 +96,21 @@ export default {
 }
 
 .calendar {
-  --rows: calc(var(--lanes) + 2);
   height: 100%;
   display: grid;
   grid-template-columns: repeat(var(--columns), var(--column-width));
-  grid-template-rows: [header] 60px [lanes] repeat(var(--lanes), auto) [remaining-space] 1fr;
+  grid-template-rows: [header] 60px [content] auto [remaining-space] 1fr;
 }
 
 .day {
-  grid-row: 1 / span var(--rows);
+  grid-row: 1 / span 3;
   grid-column: calc(var(--index) + 1); // grid starts with 1
 }
 
-.drag-wrapper {
-  display: contents;
-}
-
-.lane {
+.content {
   z-index: 1;
   margin: 20px 0;
   grid-column: 1 / span var(--columns);
-  grid-row: calc(var(--index) + 2); // grid starts with 1 + exclude header row
-
-  &__name-tag {
-    position: absolute;
-    left: calc(var(--offset-x) + 10px);
-    z-index: 1;
-    cursor: grab;
-  }
+  grid-row: 2;
 }
 </style>

--- a/src/components/timeline/Links.vue
+++ b/src/components/timeline/Links.vue
@@ -1,0 +1,87 @@
+<template>
+  <svg
+    :viewBox="`0 0 ${parentRect.width || 0} ${parentRect.height || 0}`"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <defs>
+      <marker
+        id="arrow"
+        viewBox="0 0 60 60"
+        refX="60"
+        refY="30"
+        markerUnits="strokeWidth"
+        markerWidth="16"
+        markerHeight="10"
+        orient="auto"
+      >
+        <path d="M 0 0 L 60 30 L 0 60 z" fill="black" />
+      </marker>
+    </defs>
+    <line
+      v-for="(line, index) in lines"
+      :key="index"
+      :x1="line.from[0]"
+      :y1="line.from[1]"
+      :x2="line.to[0]"
+      :y2="line.to[1]"
+      stroke="black"
+      marker-end="url(#arrow)"
+    />
+  </svg>
+</template>
+
+<script>
+import { mapGetters } from "vuex";
+import { modules } from "@/store";
+import { getLinks } from "@/store/tasks/types";
+
+export default {
+  name: "Links",
+  props: {},
+  data() {
+    return {
+      parentRect: {},
+      linkRects: [],
+      lines: []
+    };
+  },
+  mounted() {
+    this.parentRect = this.$parent.$el.getBoundingClientRect();
+    this.lines = this.calculateLineCoordinates();
+  },
+  computed: {
+    ...mapGetters(modules.tasks, {
+      links: getLinks
+    })
+  },
+  methods: {
+    getTaskElRect(taskId) {
+      const taskEl = document.querySelector(`.task[data-id="${taskId}"]`);
+      return taskEl.getBoundingClientRect();
+    },
+    calculateLineCoordinates() {
+      return this.links.map(link => {
+        const from = this.getTaskElRect(link.from);
+        const to = this.getTaskElRect(link.to);
+        return {
+          from: [
+            from.right - this.parentRect.left,
+            from.top + from.height / 2 - this.parentRect.top
+          ],
+          to: [
+            to.left - this.parentRect.left,
+            to.top + to.height / 2 - this.parentRect.top
+          ]
+        };
+      });
+    }
+  },
+  watch: {
+    links() {
+      this.lines = this.calculateLineCoordinates();
+    }
+  }
+};
+</script>
+
+<style scoped lang="scss"></style>

--- a/src/components/timeline/Links.vue
+++ b/src/components/timeline/Links.vue
@@ -41,13 +41,12 @@ export default {
   data() {
     return {
       parentRect: {},
-      linkRects: [],
       lines: []
     };
   },
   mounted() {
-    this.parentRect = this.$parent.$el.getBoundingClientRect();
-    this.lines = this.calculateLineCoordinates();
+    this.updateParentRect();
+    this.updateLineCoordinates();
   },
   computed: {
     ...mapGetters(modules.tasks, {
@@ -55,6 +54,15 @@ export default {
     })
   },
   methods: {
+    updateParentRect() {
+      this.parentRect = this.$parent.$el.getBoundingClientRect();
+    },
+    updateLineCoordinates() {
+      this.$nextTick(() => {
+        this.updateParentRect();
+        this.lines = this.calculateLineCoordinates();
+      });
+    },
     getTaskElRect(taskId) {
       const taskEl = document.querySelector(`.task[data-id="${taskId}"]`);
       return taskEl.getBoundingClientRect();
@@ -78,7 +86,7 @@ export default {
   },
   watch: {
     links() {
-      this.lines = this.calculateLineCoordinates();
+      this.updateLineCoordinates();
     }
   }
 };

--- a/src/components/timeline/Planner.vue
+++ b/src/components/timeline/Planner.vue
@@ -23,7 +23,7 @@
           ></Task>
         </template>
       </Lane>
-      <Links class="links"></Links>
+      <Links class="links" :key="linksKey"></Links>
     </Draggable>
   </div>
 </template>
@@ -84,6 +84,18 @@ export default {
         a => (heights[a.id] = this.sortedTasks[a.id].length * this.taskHeight)
       );
       return heights;
+    },
+    linksKey() {
+      /**
+       * Force rerender of the connecting lines whenever underlying DOM nodes are expected to change
+       * - order of assignees changes
+       * - new dates get rendered
+       */
+      const assigneeOrder = this.assignees.reduce(
+        (acc, curr) => `${acc},${curr.id}`,
+        ""
+      );
+      return `${this.dates.length}-${assigneeOrder}`;
     }
   },
   methods: {

--- a/src/components/timeline/Planner.vue
+++ b/src/components/timeline/Planner.vue
@@ -1,28 +1,31 @@
 <template>
-  <Draggable v-model="assignees" handle=".lane__drag-handle">
-    <Lane
-      v-for="assignee in assignees"
-      class="lane"
-      drag-handle-class="lane__drag-handle"
-      :key="assignee.id"
-      :assignee="assignee"
-      :dates="dates"
-      :scroll-offset-x="scrollOffsetX"
-      :height="laneHeight[assignee.id]"
-    >
-      <template v-for="(taskLane, index) in sortedTasks[assignee.id]">
-        <Task
-          v-for="task in taskLane"
-          :key="task.id"
-          :task="task"
-          :top="index * taskHeight"
-          :height="taskHeight"
-          :first-day-in-calendar="dates[0]"
-          :pixels-per-day="columnWidth"
-        ></Task>
-      </template>
-    </Lane>
-  </Draggable>
+  <div class="planner">
+    <Draggable v-model="assignees" handle=".lane__drag-handle">
+      <Lane
+        v-for="assignee in assignees"
+        class="lane"
+        drag-handle-class="lane__drag-handle"
+        :key="assignee.id"
+        :assignee="assignee"
+        :dates="dates"
+        :scroll-offset-x="scrollOffsetX"
+        :height="laneHeight[assignee.id]"
+      >
+        <template v-for="(taskLane, index) in sortedTasks[assignee.id]">
+          <Task
+            v-for="task in taskLane"
+            :key="task.id"
+            :task="task"
+            :top="index * taskHeight"
+            :height="taskHeight"
+            :first-day-in-calendar="dates[0]"
+            :pixels-per-day="columnWidth"
+          ></Task>
+        </template>
+      </Lane>
+      <Links class="links"></Links>
+    </Draggable>
+  </div>
 </template>
 
 <script>
@@ -34,6 +37,7 @@ import Draggable from "vuedraggable";
 
 import Lane from "@/components/timeline/Lane";
 import Task from "@/components/timeline/Task";
+import Links from "@/components/timeline/Links";
 
 import { modules } from "@/store";
 import { getAll, set } from "@/store/assignees/types";
@@ -46,7 +50,8 @@ export default {
   components: {
     Lane,
     Draggable,
-    Task
+    Task,
+    Links
   },
   props: {
     scrollOffsetX: {
@@ -124,11 +129,22 @@ export default {
 </script>
 
 <style scoped lang="scss">
+.planner {
+  position: relative;
+}
+
 .lane {
   margin-bottom: 30px;
 }
 
 .task {
   position: absolute;
+}
+
+.links {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: -1;
 }
 </style>

--- a/src/components/timeline/Planner.vue
+++ b/src/components/timeline/Planner.vue
@@ -1,0 +1,134 @@
+<template>
+  <Draggable v-model="assignees" handle=".lane__drag-handle">
+    <Lane
+      v-for="assignee in assignees"
+      class="lane"
+      drag-handle-class="lane__drag-handle"
+      :key="assignee.id"
+      :assignee="assignee"
+      :dates="dates"
+      :scroll-offset-x="scrollOffsetX"
+      :height="laneHeight[assignee.id]"
+    >
+      <template v-for="(taskLane, index) in sortedTasks[assignee.id]">
+        <Task
+          v-for="task in taskLane"
+          :key="task.id"
+          :task="task"
+          :top="index * taskHeight"
+          :height="taskHeight"
+          :first-day-in-calendar="dates[0]"
+          :pixels-per-day="columnWidth"
+        ></Task>
+      </template>
+    </Lane>
+  </Draggable>
+</template>
+
+<script>
+import Moment from "moment";
+import { extendMoment } from "moment-range";
+
+import { mapGetters } from "vuex";
+import Draggable from "vuedraggable";
+
+import Lane from "@/components/timeline/Lane";
+import Task from "@/components/timeline/Task";
+
+import { modules } from "@/store";
+import { getAll, set } from "@/store/assignees/types";
+import { getByAssignee } from "@/store/tasks/types";
+
+const moment = extendMoment(Moment);
+
+export default {
+  name: "Planner",
+  components: {
+    Lane,
+    Draggable,
+    Task
+  },
+  props: {
+    scrollOffsetX: {
+      type: Number,
+      required: true
+    },
+    dates: {
+      type: Array,
+      validator: prop => prop.every(e => e instanceof moment)
+    }
+  },
+  computed: {
+    ...mapGetters(modules.tasks, { tasksByAssignee: getByAssignee }),
+    assignees: {
+      get() {
+        return this.$store.getters[`${modules.assignees}/${getAll}`];
+      },
+      set(value) {
+        this.$store.commit(`${modules.assignees}/${set}`, value);
+      }
+    },
+    sortedTasks() {
+      let tasks = {};
+      this.assignees.forEach(a => (tasks[a.id] = this.sortTasks(a.id)));
+      return tasks;
+    },
+    laneHeight() {
+      const heights = {};
+      this.assignees.forEach(
+        a => (heights[a.id] = this.sortedTasks[a.id].length * this.taskHeight)
+      );
+      return heights;
+    }
+  },
+  methods: {
+    tasksOverlap(a, b) {
+      const rangeA = moment.range(a.start, a.end);
+      const rangeB = moment.range(b.start, b.end);
+      return rangeA.overlaps(rangeB);
+    },
+
+    sortTasks(assigneeId) {
+      const tasks = this.tasksByAssignee(assigneeId) || [];
+      let lanes = [];
+      tasks
+        .slice()
+        .sort((a, b) => a.start.diff(b.start))
+        .forEach(task => {
+          let sorted = false;
+          let i = 0;
+          while (!sorted) {
+            if (lanes[i] == null) {
+              lanes[i] = [task];
+              sorted = true;
+            } else if (
+              lanes[i].every(sortedTask => !this.tasksOverlap(sortedTask, task))
+            ) {
+              lanes[i].push(task);
+              sorted = true;
+            } else {
+              i++;
+            }
+          }
+        });
+      return lanes;
+    }
+  },
+  data() {
+    return {
+      columnWidth: 50,
+      taskHeight: 30
+    };
+  }
+};
+</script>
+
+<style scoped lang="scss">
+.lane {
+  margin-bottom: 30px;
+}
+
+.task {
+  position: absolute;
+}
+</style>

--- a/src/components/timeline/Task.vue
+++ b/src/components/timeline/Task.vue
@@ -106,7 +106,7 @@ import {
   addLink,
   update,
   remove,
-  getLinksByTask,
+  getLinksFromTask,
   removeLink
 } from "@/store/tasks/types";
 import { getById } from "@/store/projects/types";
@@ -151,7 +151,7 @@ export default {
     };
   },
   computed: {
-    ...mapGetters(modules.tasks, { getLinksByTask: getLinksByTask }),
+    ...mapGetters(modules.tasks, { getLinksFromTask: getLinksFromTask }),
     ...mapGetters(modules.projects, { getProject: getById }),
     ...mapGetters(modules.ui, { linkingTask: getLinkingTask }),
     project() {
@@ -176,7 +176,7 @@ export default {
     },
     linkingTaskLinks() {
       return this.isCurrentlyLinking
-        ? this.getLinksByTask(this.linkingTask)
+        ? this.getLinksFromTask(this.linkingTask)
         : [];
     },
     isLinkingTask() {
@@ -195,10 +195,10 @@ export default {
   },
   methods: {
     ...mapMutations(modules.tasks, {
-      deleteTask: remove,
       removeLinkInStore: removeLink
     }),
     ...mapActions(modules.tasks, {
+      deleteTask: remove,
       addLinkInStore: addLink,
       editTask: update
     }),

--- a/src/components/timeline/Task.vue
+++ b/src/components/timeline/Task.vue
@@ -94,7 +94,7 @@
 
 <script>
 import VueDraggableResizable from "vue-draggable-resizable";
-import { mapGetters, mapMutations } from "vuex";
+import { mapActions, mapGetters, mapMutations } from "vuex";
 import moment from "moment";
 
 import { getContrastColor } from "@/utils";
@@ -104,7 +104,7 @@ import { modules } from "@/store";
 import { isTask } from "@/store/tasks/schema";
 import {
   addLink,
-  edit,
+  update,
   remove,
   getLinksByTask,
   removeLink
@@ -195,10 +195,12 @@ export default {
   },
   methods: {
     ...mapMutations(modules.tasks, {
-      editTask: edit,
       deleteTask: remove,
       addLinkInStore: addLink,
       removeLinkInStore: removeLink
+    }),
+    ...mapActions(modules.tasks, {
+      editTask: update
     }),
     ...mapMutations(modules.ui, { setLinkingTask: setLinkingTask }),
     getSpaceBetween(start, end) {

--- a/src/components/timeline/Task.vue
+++ b/src/components/timeline/Task.vue
@@ -16,6 +16,7 @@
     drag-handle=".task__drag-area"
     class="task"
     :style="cssVars"
+    :data-id="task.id"
   >
     <div class="task__content">
       <v-btn

--- a/src/components/timeline/Task.vue
+++ b/src/components/timeline/Task.vue
@@ -196,10 +196,10 @@ export default {
   methods: {
     ...mapMutations(modules.tasks, {
       deleteTask: remove,
-      addLinkInStore: addLink,
       removeLinkInStore: removeLink
     }),
     ...mapActions(modules.tasks, {
+      addLinkInStore: addLink,
       editTask: update
     }),
     ...mapMutations(modules.ui, { setLinkingTask: setLinkingTask }),

--- a/src/store/assignees/index.js
+++ b/src/store/assignees/index.js
@@ -26,10 +26,14 @@ export default {
     [edit]: (state, assignee) => {
       const i = state.findIndex(a => a.id === assignee.id);
       Vue.set(state, i, assignee);
-    },
-    [remove](state, assigneeId) {
+    }
+  },
+  actions: {
+    [remove]({ state, dispatch }, assigneeId) {
       const i = state.findIndex(a => a.id === assigneeId);
-      this.commit(`${modules.tasks}/${removeByAssignee}`, assigneeId);
+      dispatch(`${modules.tasks}/${removeByAssignee}`, assigneeId, {
+        root: true
+      });
       Vue.delete(state, i);
     }
   }

--- a/src/store/assignees/types.js
+++ b/src/store/assignees/types.js
@@ -5,4 +5,6 @@ export const getAll = "GET_ALL";
 export const set = "SET";
 export const add = "ADD";
 export const edit = "EDIT";
+
+/** Actions */
 export const remove = "REMOVE";

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -4,12 +4,14 @@ import Vuex from "vuex";
 import tasks from "@/store/tasks";
 import assignees from "@/store/assignees";
 import projects from "@/store/projects";
+import ui from "@/store/ui";
 import { INIT_STORE, persist } from "@/store/plugins";
 
 export const modules = {
   tasks: "tasks",
   assignees: "assignees",
-  projects: "projects"
+  projects: "projects",
+  ui: "ui"
 };
 
 Vue.use(Vuex);
@@ -19,7 +21,8 @@ export default new Vuex.Store({
   modules: {
     [modules.tasks]: tasks,
     [modules.assignees]: assignees,
-    [modules.projects]: projects
+    [modules.projects]: projects,
+    [modules.ui]: ui
   },
   mutations: {
     [INIT_STORE]: (state, init) => Object.assign(state, init)

--- a/src/store/projects/index.js
+++ b/src/store/projects/index.js
@@ -41,16 +41,20 @@ export default {
       const i = state.items.findIndex(a => a.id === project.id);
       Vue.set(state.items, i, project);
     },
-    [remove](state, projectId) {
+    [select](state, projectId) {
+      state.selected = projectId;
+    }
+  },
+  actions: {
+    [remove]({ state, dispatch }, projectId) {
       const i = state.items.findIndex(a => a.id === projectId);
-      this.commit(`${modules.tasks}/${removeByProject}`, projectId);
+      dispatch(`${modules.tasks}/${removeByProject}`, projectId, {
+        root: true
+      });
       Vue.delete(state.items, i);
       if ((state.selected = projectId)) {
         state.selected = state.items[0]?.id;
       }
-    },
-    [select](state, projectId) {
-      state.selected = projectId;
     }
   }
 };

--- a/src/store/projects/types.js
+++ b/src/store/projects/types.js
@@ -7,5 +7,7 @@ export const getById = "GET_BY_ID";
 export const set = "SET";
 export const add = "ADD";
 export const edit = "EDIT";
-export const remove = "REMOVE";
 export const select = "SELECT";
+
+/** Actions */
+export const remove = "REMOVE";

--- a/src/store/tasks/index.js
+++ b/src/store/tasks/index.js
@@ -9,6 +9,8 @@ import {
   getAll,
   getByAssignee,
   getLinks,
+  getLinksByTask,
+  getOne,
   remove,
   removeByAssignee,
   removeByProject,
@@ -31,7 +33,8 @@ const parse = task => ({
 });
 
 const selectAll = state => Object.values(state).map(parse);
-// const selectOne = state => taskId => selectAll(state)[taskId];
+const selectOne = state => taskId =>
+  selectAll(state).find(t => t.id === taskId);
 const selectByAssignee = state => assigneeId =>
   selectAll(state).filter(task => task.assignee === assigneeId);
 const selectByProject = state => projectId =>
@@ -43,6 +46,7 @@ export default {
   getters: {
     [getAll]: selectAll,
     [getByAssignee]: selectByAssignee,
+    [getOne]: selectOne,
     [getLinks]: state => {
       const tasks = selectAll(state);
       const linkTuples = [];
@@ -55,6 +59,10 @@ export default {
         });
       });
       return linkTuples;
+    },
+    [getLinksByTask]: (state, getters) => taskId => {
+      const task = getters[getOne](taskId);
+      return task.links;
     }
   },
   mutations: {
@@ -74,8 +82,8 @@ export default {
       }
     },
     [removeLink]: (state, { from, to }) => {
-      //TODO
-      console.log("remove", from, to);
+      const newLinks = state[from].links.filter(link => link !== to);
+      Vue.set(state[from], "links", newLinks);
     },
     [remove]: (state, taskId) => {
       Vue.delete(state, taskId);

--- a/src/store/tasks/index.js
+++ b/src/store/tasks/index.js
@@ -75,13 +75,6 @@ export default {
     [internalUpdateSingle]: (state, task) => {
       Vue.set(state, task.id, stringify(task));
     },
-    [addLink]: (state, { from, to }) => {
-      const fromTask = state[from];
-      const toIsValid = to !== null && to !== undefined;
-      if (fromTask && toIsValid && !fromTask.links.includes(to)) {
-        fromTask.links.push(to);
-      }
-    },
     [removeLink]: (state, { from, to }) => {
       const newLinks = state[from].links.filter(link => link !== to);
       Vue.set(state[from], "links", newLinks);
@@ -145,6 +138,16 @@ export default {
           });
         }
       });
+    },
+    [addLink]: ({ dispatch, getters }, { from, to }) => {
+      const fromTask = getters[getOne](from);
+      const toIsValid = to !== null && to !== undefined;
+      if (fromTask && toIsValid && !fromTask.links.includes(to)) {
+        dispatch(update, {
+          ...fromTask,
+          links: [...fromTask.links, to]
+        });
+      }
     }
   }
 };

--- a/src/store/tasks/index.js
+++ b/src/store/tasks/index.js
@@ -8,6 +8,7 @@ import {
   edit,
   getAll,
   getByAssignee,
+  getLinks,
   remove,
   removeByAssignee,
   removeByProject,
@@ -41,7 +42,20 @@ export default {
   state: {},
   getters: {
     [getAll]: selectAll,
-    [getByAssignee]: selectByAssignee
+    [getByAssignee]: selectByAssignee,
+    [getLinks]: state => {
+      const tasks = selectAll(state);
+      const linkTuples = [];
+      tasks.forEach(task => {
+        task.links.forEach(link => {
+          linkTuples.push({
+            from: task.id,
+            to: link
+          });
+        });
+      });
+      return linkTuples;
+    }
   },
   mutations: {
     [add]: (state, task) => {

--- a/src/store/tasks/index.js
+++ b/src/store/tasks/index.js
@@ -4,12 +4,14 @@ import moment from "moment";
 
 import {
   add,
+  addLink,
   edit,
   getAll,
   getByAssignee,
   remove,
   removeByAssignee,
-  removeByProject
+  removeByProject,
+  removeLink
 } from "@/store/tasks/types";
 import { generateNewId } from "@/utils";
 
@@ -28,6 +30,7 @@ const parse = task => ({
 });
 
 const selectAll = state => Object.values(state).map(parse);
+// const selectOne = state => taskId => selectAll(state)[taskId];
 const selectByAssignee = state => assigneeId =>
   selectAll(state).filter(task => task.assignee === assigneeId);
 const selectByProject = state => projectId =>
@@ -43,10 +46,22 @@ export default {
   mutations: {
     [add]: (state, task) => {
       task.id = generateNewId(Object.keys(state));
+      task.links = [];
       Vue.set(state, task.id, stringify(task));
     },
     [edit]: (state, task) => {
       Vue.set(state, task.id, stringify(task));
+    },
+    [addLink]: (state, { from, to }) => {
+      const fromTask = state[from];
+      const toIsValid = to !== null && to !== undefined;
+      if (fromTask && toIsValid && !fromTask.links.includes(to)) {
+        fromTask.links.push(to);
+      }
+    },
+    [removeLink]: (state, { from, to }) => {
+      //TODO
+      console.log("remove", from, to);
     },
     [remove]: (state, taskId) => {
       Vue.delete(state, taskId);

--- a/src/store/tasks/schema.js
+++ b/src/store/tasks/schema.js
@@ -1,5 +1,6 @@
 import moment from "moment";
 import {
+  isArrayOf,
   isInstance,
   isNull,
   isType,
@@ -15,7 +16,8 @@ const task = {
   assignee: assignee.id,
   project: value => project.id(value) || isNull(value),
   start: isInstance(moment),
-  end: isInstance(moment)
+  end: isInstance(moment),
+  links: isArrayOf("number")
 };
 
 export const isTask = object => validateSchema(object, task);

--- a/src/store/tasks/types.js
+++ b/src/store/tasks/types.js
@@ -5,6 +5,8 @@ export const getByAssignee = "GET_BY_ASSIGNEE";
 /** Mutations */
 export const add = "ADD";
 export const edit = "EDIT";
+export const addLink = "ADD_LINK";
+export const removeLink = "REMOVE_LINK";
 export const remove = "REMOVE";
 export const removeByAssignee = "REMOVE_BY_ASSIGNEE";
 export const removeByProject = "REMOVE_BY_PROJECT";

--- a/src/store/tasks/types.js
+++ b/src/store/tasks/types.js
@@ -1,6 +1,7 @@
 /** Getters */
 export const getAll = "GET_ALL";
 export const getByAssignee = "GET_BY_ASSIGNEE";
+export const getLinks = "GET_LINKS";
 
 /** Mutations */
 export const add = "ADD";

--- a/src/store/tasks/types.js
+++ b/src/store/tasks/types.js
@@ -2,16 +2,21 @@
 export const getOne = "GET_ONE";
 export const getAll = "GET_ALL";
 export const getByAssignee = "GET_BY_ASSIGNEE";
+export const getByProject = "GET_BY_PROJECT";
 export const getLinks = "GET_LINKS";
-export const getLinksByTask = "GET_LINKS_BY_TASK";
+export const getLinksFromTask = "GET_LINKS_FROM_TASK";
+export const getLinksToTask = "GET_LINKS_TO_TASK";
 
 /** Mutations */
 export const add = "ADD";
-export const update = "UPDATE";
-export const addLink = "ADD_LINK";
 export const removeLink = "REMOVE_LINK";
+
+export const internalUpdateSingle = "INTERNAL/UPDATE_SINGLE";
+export const internalRemoveSingle = "INTERNAL/REMOVE_SINGLE";
+
+/** Actions */
+export const addLink = "ADD_LINK";
+export const update = "UPDATE";
 export const remove = "REMOVE";
 export const removeByAssignee = "REMOVE_BY_ASSIGNEE";
 export const removeByProject = "REMOVE_BY_PROJECT";
-
-export const internalUpdateSingle = "INTERNAL/UPDATE_SINGLE";

--- a/src/store/tasks/types.js
+++ b/src/store/tasks/types.js
@@ -7,9 +7,11 @@ export const getLinksByTask = "GET_LINKS_BY_TASK";
 
 /** Mutations */
 export const add = "ADD";
-export const edit = "EDIT";
+export const update = "UPDATE";
 export const addLink = "ADD_LINK";
 export const removeLink = "REMOVE_LINK";
 export const remove = "REMOVE";
 export const removeByAssignee = "REMOVE_BY_ASSIGNEE";
 export const removeByProject = "REMOVE_BY_PROJECT";
+
+export const internalUpdateSingle = "INTERNAL/UPDATE_SINGLE";

--- a/src/store/tasks/types.js
+++ b/src/store/tasks/types.js
@@ -1,7 +1,9 @@
 /** Getters */
+export const getOne = "GET_ONE";
 export const getAll = "GET_ALL";
 export const getByAssignee = "GET_BY_ASSIGNEE";
 export const getLinks = "GET_LINKS";
+export const getLinksByTask = "GET_LINKS_BY_TASK";
 
 /** Mutations */
 export const add = "ADD";

--- a/src/store/ui/index.js
+++ b/src/store/ui/index.js
@@ -1,0 +1,20 @@
+import Vue from "vue";
+import Vuex from "vuex";
+import { getLinkingTask, setLinkingTask } from "@/store/ui/types";
+
+Vue.use(Vuex);
+
+export default {
+  namespaced: true,
+  state: {
+    linkingTask: null
+  },
+  getters: {
+    [getLinkingTask]: state => state.linkingTask
+  },
+  mutations: {
+    [setLinkingTask]: (state, taskId) => {
+      Vue.set(state, "linkingTask", taskId);
+    }
+  }
+};

--- a/src/store/ui/types.js
+++ b/src/store/ui/types.js
@@ -1,0 +1,5 @@
+/** Getters */
+export const getLinkingTask = "GET_LINKING_TASK";
+
+/** Mutations */
+export const setLinkingTask = "SET_LINKING_TASK";

--- a/src/utils.js
+++ b/src/utils.js
@@ -35,6 +35,8 @@ export const generateNewId = currentIds => {
 export const isType = type => value => typeof value === type;
 export const isInstance = type => value => value instanceof type;
 export const isNull = value => value === null;
+export const isArrayOf = type => value =>
+  typeof value === "object" && value.map(isType(type));
 
 /**
  * Validate if a given object has _all_ properties required by the schema

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -4,7 +4,11 @@
       <AddAssigneeButton />
       <ProjectButtons />
     </div>
-    <Calendar />
+    <Calendar>
+      <template v-slot:default="{ scrollOffsetX, dates }">
+        <Planner :scroll-offset-x="scrollOffsetX" :dates="dates"></Planner>
+      </template>
+    </Calendar>
   </div>
 </template>
 
@@ -12,12 +16,14 @@
 import Calendar from "@/components/timeline/Calendar";
 import AddAssigneeButton from "@/components/assignees/AddAssigneeButton";
 import ProjectButtons from "@/components/projects/ProjectButtons";
+import Planner from "@/components/timeline/Planner";
 
 export default {
   name: "Timeline",
   components: {
     AddAssigneeButton,
     Calendar,
+    Planner,
     ProjectButtons
   }
 };


### PR DESCRIPTION
It is now possible to add links between to tasks to create a dependency between them. Whenever a task's end date is updated every task that is dependent on said task will get moved to the future to avoid any overlap. Additionally, whenever a task's start date is updated all other tasks, that this task depends on, are pushed to the past.

![GIF 17 07 2020 13-39-36](https://user-images.githubusercontent.com/12427993/87785367-564f9000-c838-11ea-8f58-6bc317e9956a.gif)
