### PR TITLE
Omit weekends from calendar and only allow tasks on business days

### DIFF
--- a/client/src/components/timeline/Calendar.vue
+++ b/client/src/components/timeline/Calendar.vue
@@ -2,17 +2,13 @@
   <div class="scroll-wrapper" @scroll="onScroll">
     <div class="calendar" :style="cssVars">
       <div class="content">
-        <slot
-          :scrollOffsetX="offsetX"
-          :dates="days"
-          :zoomLevel="columnWidth"
-        ></slot>
+        <slot></slot>
       </div>
       <Day
-        v-for="(day, index) in days"
+        v-for="(day, index) in dates"
+        :key="day.format()"
         class="day"
         :style="`--index: ${index};`"
-        :key="day.format()"
         :date="day"
         :minimal="columnWidth <= 40"
       ></Day>
@@ -28,12 +24,20 @@
 </template>
 
 <script>
-import Moment from "moment";
-import { extendMoment } from "moment-range";
+import moment from "moment";
 import Day from "@/components/timeline/Day";
 import ZoomControls from "@/components/timeline/ZoomControls";
-
-const moment = extendMoment(Moment);
+import dates from "@/mixins/dates";
+import { mapGetters, mapMutations } from "vuex";
+import { modules } from "@/store";
+import {
+  getDates,
+  getPixelsPerDay,
+  getScrollXOffset,
+  setDates,
+  setPixelsPerDay,
+  setScrollXOffset
+} from "@/store/calendar/types";
 
 export default {
   name: "Calendar",
@@ -41,69 +45,86 @@ export default {
     Day,
     ZoomControls
   },
+  mixins: [dates],
   computed: {
+    ...mapGetters(modules.calendar, {
+      columnWidth: getPixelsPerDay,
+      offsetX: getScrollXOffset,
+      dates: getDates
+    }),
     cssVars() {
       return {
-        "--columns": this.days.length,
+        "--columns": this.dates.length,
         "--column-width": `${this.columnWidth}px`,
         "--offset-x": `${this.offsetX}px`
       };
     }
   },
   methods: {
+    ...mapMutations(modules.calendar, {
+      setPixelsPerDay: setPixelsPerDay,
+      setOffsetX: setScrollXOffset,
+      setDates: setDates
+    }),
+
     onScroll(e) {
-      this.offsetX = e.target.scrollLeft;
-      const offsetRight = this.offsetX + e.target.clientWidth;
-      const calendarWidth = this.days.length * this.columnWidth;
+      const offsetLeft = e.target.scrollLeft;
+      this.setOffsetX(offsetLeft);
+      const offsetRight = offsetLeft + e.target.clientWidth;
+      const calendarWidth = this.dates.length * this.columnWidth;
       if (calendarWidth <= offsetRight) {
         this.loadFutureDays();
-      } else if (this.offsetX <= 0) {
+      } else if (offsetLeft <= 0) {
         this.loadPastDays();
       }
     },
+
     loadFutureDays() {
-      const lastDay = this.days[this.days.length - 1];
-      const range = moment
-        .range(moment(lastDay).add(1, "d"), moment(lastDay).add(6, "w"))
-        .by("day");
-      const newDays = Array.from(range).map(d => d.startOf("d"));
-      this.days = [...this.days, ...newDays];
+      const lastDay = this.dates[this.dates.length - 1];
+      const newDays = this.getBusinessDaysBetween(
+        moment(lastDay).add(1, "d"),
+        moment(lastDay).add(6, "w")
+      );
+      this.setDates([...this.dates, ...newDays]);
     },
+
     loadPastDays() {
-      const firstDay = this.days[0];
-      const range = moment
-        .range(
-          moment(firstDay).subtract(6, "w"),
-          moment(firstDay).subtract(1, "d")
-        )
-        .by("day");
-      const newDays = Array.from(range).map(d => d.startOf("d"));
-      this.days = [...newDays, ...this.days];
+      const firstDay = this.dates[0];
+      const newDays = this.getBusinessDaysBetween(
+        moment(firstDay).subtract(6, "w"),
+        moment(firstDay).subtract(1, "d")
+      );
+      this.setDates([...newDays, ...this.dates]);
       this.$el.scrollTo(newDays.length * this.columnWidth, 0);
     },
+
+    loadInitialDays() {
+      const initialDays = this.getBusinessDaysBetween(
+        moment().subtract(3, "weeks"),
+        moment().add(6, "weeks")
+      );
+      this.setDates(initialDays);
+    },
+
+    scrollToDate(day) {
+      const calendarWidth = this.$el.clientWidth;
+      const positionOfToday = this.getPositionOfDay(day);
+      this.$el.scrollTo(positionOfToday - calendarWidth / 3, 0);
+    },
+
     onZoom(level) {
       const daysOutsideViewport = this.offsetX / this.columnWidth;
       const zoomFactor = (this.columnWidth ^ 2) / 2;
-      this.columnWidth += level * zoomFactor;
-      this.$el.scrollTo(daysOutsideViewport * this.columnWidth, 0);
+      const newColumnWidth = this.columnWidth + level * zoomFactor;
+      this.setPixelsPerDay(newColumnWidth);
+      this.$el.scrollTo(daysOutsideViewport * newColumnWidth, 0);
     }
   },
-  mounted() {
-    const today = moment();
-    const indexOfToday = this.days.findIndex(day => day.isSame(today, "d"));
-    const calendarWidth = this.$el.clientWidth;
-    this.$el.scrollTo(indexOfToday * this.columnWidth - calendarWidth / 3, 0);
+  created() {
+    this.loadInitialDays();
   },
-  data() {
-    const range = moment
-      .range(moment().subtract(3, "weeks"), moment().add(6, "weeks"))
-      .by("day");
-    return {
-      days: Array.from(range).map(d => d.startOf("d")),
-      columnWidth: 40,
-      offsetX: 0,
-      dragging: false
-    };
+  mounted() {
+    this.scrollToDate(moment());
   }
 };
 </script>

--- a/client/src/components/timeline/Day.vue
+++ b/client/src/components/timeline/Day.vue
@@ -1,9 +1,10 @@
 <template>
   <div
+    v-if="!isWeekend"
     :class="
       `day
-      ${isWeekend(date) ? 'day--weekend' : ''}
-      ${isToday(date) ? 'day--today' : ''}`
+      ${isToday ? 'day--today' : ''}
+      ${isFriday ? 'day--friday' : ''}`
     "
   >
     <v-tooltip top>
@@ -33,17 +34,21 @@ export default {
     date: moment,
     minimal: {
       type: Boolean,
-      default: true,
-      required: false
+      required: false,
+      default: false
     }
   },
-  methods: {
-    isToday(day) {
-      return day.isSame(today, "day");
+  computed: {
+    isToday() {
+      return this.date.isSame(today, "day");
     },
-    isWeekend(day) {
-      const weekday = day.format("e");
+    isWeekend() {
+      const weekday = this.date.format("e");
       return weekday === "0" || weekday === "6";
+    },
+    isFriday() {
+      const weekday = this.date.format("e");
+      return weekday === "5";
     }
   }
 };
@@ -51,18 +56,12 @@ export default {
 
 <style scoped lang="scss">
 .day {
-  border: 1px solid #efefef;
+  border-right: 1px solid #efefef;
   display: flex;
   flex-direction: column;
 
-  &--weekend {
-    background: repeating-linear-gradient(
-      -55deg,
-      transparent,
-      transparent 5px,
-      #efefef 5px,
-      #efefef 10px
-    );
+  &--friday {
+    border-right-color: #8f8f8f;
   }
 
   &__header {

--- a/client/src/components/timeline/Planner.vue
+++ b/client/src/components/timeline/Planner.vue
@@ -7,10 +7,7 @@
         drag-handle-class="lane__drag-handle"
         :key="assignee.id"
         :assignee="assignee"
-        :dates="dates"
-        :scroll-offset-x="scrollOffsetX"
         :height="laneHeight[assignee.id]"
-        :columnWidth="zoomLevel"
       >
         <template v-for="(taskLane, index) in sortedTasks[assignee.id]">
           <Task
@@ -19,8 +16,6 @@
             :task="task"
             :top="index * taskHeight"
             :height="taskHeight"
-            :first-day-in-calendar="dates[0]"
-            :pixels-per-day="zoomLevel"
           ></Task>
         </template>
       </Lane>
@@ -43,6 +38,7 @@ import Links from "@/components/timeline/Links";
 import { modules } from "@/store";
 import { getAll, set } from "@/store/assignees/types";
 import { getByAssignee } from "@/store/tasks/types";
+import { getPixelsPerDay, getDates } from "@/store/calendar/types";
 
 const moment = extendMoment(Moment);
 
@@ -54,23 +50,17 @@ export default {
     Task,
     Links
   },
-  props: {
-    scrollOffsetX: {
-      type: Number,
-      required: true
-    },
-    zoomLevel: {
-      type: Number,
-      required: false,
-      default: 0
-    },
-    dates: {
-      type: Array,
-      validator: prop => prop.every(e => e instanceof moment)
-    }
+  data() {
+    return {
+      taskHeight: 30
+    };
   },
   computed: {
     ...mapGetters(modules.tasks, { tasksByAssignee: getByAssignee }),
+    ...mapGetters(modules.calendar, {
+      dates: getDates,
+      zoomLevel: getPixelsPerDay
+    }),
     assignees: {
       get() {
         return this.$store.getters[`${modules.assignees}/${getAll}`];
@@ -101,7 +91,7 @@ export default {
         (acc, curr) => `${acc},${curr.id}`,
         ""
       );
-      return `${this.zoomLevel}-${this.dates.length}-${assigneeOrder}`;
+      return `${this.zoomLevel}-${this.dates?.length}-${assigneeOrder}`;
     }
   },
   methods: {
@@ -136,11 +126,6 @@ export default {
         });
       return lanes;
     }
-  },
-  data() {
-    return {
-      taskHeight: 30
-    };
   }
 };
 </script>

--- a/client/src/mixins/dates.js
+++ b/client/src/mixins/dates.js
@@ -1,0 +1,38 @@
+import { mapGetters } from "vuex";
+import { modules } from "@/store";
+import { getDates, getPixelsPerDay } from "@/store/calendar/types";
+import { getBusinessDaysBetween } from "@/utils";
+
+export default {
+  computed: {
+    ...mapGetters(modules.calendar, {
+      pixelsPerDay: getPixelsPerDay,
+      dates: getDates
+    }),
+
+    firstDayInCalendar() {
+      return this.dates[0];
+    }
+  },
+
+  methods: {
+    getBusinessDaysBetween(start, end) {
+      return getBusinessDaysBetween(start, end);
+    },
+
+    getDayByPositionX(positionX) {
+      const index = Math.floor(positionX / this.pixelsPerDay);
+      return this.dates[index];
+    },
+
+    getPositionOfDay(day) {
+      return this.getSpaceBetweenDays(this.firstDayInCalendar, day);
+    },
+
+    getSpaceBetweenDays(start, end, includeEndDay = false) {
+      const daysBetween = this.getBusinessDaysBetween(start, end).length;
+      const adjustedDaysBetween = includeEndDay ? daysBetween : daysBetween - 1;
+      return adjustedDaysBetween * this.pixelsPerDay;
+    }
+  }
+};

--- a/client/src/store/calendar/index.js
+++ b/client/src/store/calendar/index.js
@@ -1,0 +1,37 @@
+import Vue from "vue";
+import Vuex from "vuex";
+import {
+  getDates,
+  getPixelsPerDay,
+  getScrollXOffset,
+  setDates,
+  setPixelsPerDay,
+  setScrollXOffset
+} from "@/store/calendar/types";
+
+Vue.use(Vuex);
+
+export default {
+  namespaced: true,
+  state: {
+    pixelsPerDay: 40,
+    scrollXOffset: 0,
+    dates: []
+  },
+  getters: {
+    [getPixelsPerDay]: state => state.pixelsPerDay,
+    [getScrollXOffset]: state => state.scrollXOffset,
+    [getDates]: state => state.dates
+  },
+  mutations: {
+    [setPixelsPerDay]: (state, pixels) => {
+      Vue.set(state, "pixelsPerDay", pixels);
+    },
+    [setScrollXOffset]: (state, offset) => {
+      Vue.set(state, "scrollXOffset", offset);
+    },
+    [setDates]: (state, dates) => {
+      Vue.set(state, "dates", dates);
+    }
+  }
+};

--- a/client/src/store/calendar/types.js
+++ b/client/src/store/calendar/types.js
@@ -1,0 +1,9 @@
+/** Getters */
+export const getPixelsPerDay = "GET_PIXELS_PER_DAY";
+export const getScrollXOffset = "GET_SCROLL_X_OFFSET";
+export const getDates = "GET_DATES";
+
+/** Mutations */
+export const setPixelsPerDay = "SET_PIXELS_PER_DAY";
+export const setScrollXOffset = "SET_SCROLL_X_OFFSET";
+export const setDates = "SET_DATES";

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -6,13 +6,15 @@ import assignees from "@/store/assignees";
 import projects from "@/store/projects";
 import boards from "@/store/boards";
 import ui from "@/store/ui";
+import calendar from "@/store/calendar";
 
 export const modules = {
   tasks: "tasks",
   assignees: "assignees",
   projects: "projects",
   boards: "boards",
-  ui: "ui"
+  ui: "ui",
+  calendar: "calendar"
 };
 
 Vue.use(Vuex);
@@ -24,6 +26,7 @@ export default new Vuex.Store({
     [modules.assignees]: assignees,
     [modules.projects]: projects,
     [modules.boards]: boards,
-    [modules.ui]: ui
+    [modules.ui]: ui,
+    [modules.calendar]: calendar
   }
 });

--- a/client/src/utils.js
+++ b/client/src/utils.js
@@ -29,6 +29,37 @@ export const generateNewId = currentIds => {
 };
 
 /** =========================
+ *  Date Handling
+ *  =========================
+ */
+import Moment from "moment";
+import { extendMoment } from "moment-range";
+
+const moment = extendMoment(Moment);
+
+const isBusinessDay = date => date.isoWeekday() < 6;
+
+export const getBusinessDaysBetween = (start, end) => {
+  const range = moment.range(start, end).by("day");
+  return Array.from(range)
+    .map(d => d.startOf("d"))
+    .filter(isBusinessDay);
+};
+
+export const addBusinessDays = (date, days) => {
+  date = moment(date);
+  let absoluteDays = Math.abs(days);
+  const increment = days / absoluteDays;
+  while (absoluteDays > 0) {
+    date = date.add(increment, "d");
+    if (isBusinessDay(date)) {
+      absoluteDays -= 1;
+    }
+  }
+  return date;
+};
+
+/** =========================
  *  Validating Object Schemas
  *  =========================
  */

--- a/client/src/views/Timeline.vue
+++ b/client/src/views/Timeline.vue
@@ -5,13 +5,7 @@
       <ProjectButtons />
     </div>
     <Calendar>
-      <template v-slot:default="{ scrollOffsetX, dates, zoomLevel }">
-        <Planner
-          :scroll-offset-x="scrollOffsetX"
-          :dates="dates"
-          :zoom-level="zoomLevel"
-        ></Planner>
-      </template>
+      <Planner></Planner>
     </Calendar>
 
     <v-overlay :value="loading">


### PR DESCRIPTION
- Only show business days in calendar and ignore weekends for calculating a task's duration
- Refactor calendar props to be in vuex store slice, instead of handing them through multiple components
- Extract calculations related to dates and their positions in the calendar into a shared mixin